### PR TITLE
feat: add wallet connection modal to Swap component

### DIFF
--- a/src/pages/Swap.tsx
+++ b/src/pages/Swap.tsx
@@ -35,6 +35,7 @@ import AppLayout from '../AppLayout.tsx'
 import { ChargeFeeBy } from '@anqa-ag/ts-sdk'
 import { Helmet } from 'react-helmet'
 import { useTokenBalance } from '../hooks/useRefreshBalanceFn.ts'
+import ModalConnectWallet from '../components/modals/ModalConnectWallet.tsx'
 
 export default function Swap() {
   const dispatch = useAppDispatch()
@@ -949,7 +950,11 @@ export default function Swap() {
         onClose={onCloseModal}
         onSelectToken={setTokenIn}
       />
-
+      <ModalConnectWallet
+        isOpen={globalModal === MODAL_LIST.CONNECT_WALLET && isModalOpen}
+        onOpenChange={onOpenChangeModal}
+        onClose={onCloseModal}
+      />
       <ModalSelectToken
         isOpen={globalModal === MODAL_LIST.SELECT_TOKEN_OUT && isModalOpen}
         onOpenChange={onOpenChangeModal}


### PR DESCRIPTION
This pull request introduces a new `ModalConnectWallet` component to the `Swap` page, enabling users to connect their wallets directly from the modal interface. The changes include importing the new component and integrating it into the modal management logic.

### Changes related to wallet connection:

* [`src/pages/Swap.tsx`](diffhunk://#diff-065ec95a6f3d57a9efb77837648630e1019ad50a30b9d640e50da9dec483309eR38): Added the `ModalConnectWallet` component to the imports and integrated it into the `Swap` page. The modal is conditionally rendered based on the `globalModal` state and the `MODAL_LIST.CONNECT_WALLET` constant, allowing users to connect their wallets. [[1]](diffhunk://#diff-065ec95a6f3d57a9efb77837648630e1019ad50a30b9d640e50da9dec483309eR38) [[2]](diffhunk://#diff-065ec95a6f3d57a9efb77837648630e1019ad50a30b9d640e50da9dec483309eL952-R957)