### PR TITLE
feat: add new stable coin USDA

### DIFF
--- a/src/components/modals/ModalSelectToken.tsx
+++ b/src/components/modals/ModalSelectToken.tsx
@@ -20,6 +20,7 @@ const STABLE_COIN_IDS = [
   '0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDT',
   '0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDC',
   '0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b',
+  '0x534e4c3dc0f038dab1a8259e89301c4da58779a5d482fb354a41c08147e6b9ec',
 ]
 
 export interface TokenWithBalance extends Asset {


### PR DESCRIPTION
This pull request makes a small update to the list of stable coin IDs in the `ModalSelectToken.tsx` component by adding a new token identifier. This change ensures that the new token will be recognized as a stable coin in the modal.

* Added `'0x534e4c3dc0f038dab1a8259e89301c4da58779a5d482fb354a41c08147e6b9ec'` (USDA) to the `STABLE_COIN_IDS` array in `src/components/modals/ModalSelectToken.tsx`